### PR TITLE
Fix import order in experimental __init__

### DIFF
--- a/netket/experimental/__init__.py
+++ b/netket/experimental/__init__.py
@@ -25,16 +25,16 @@ __all__ = [
     "observable",
 ]
 
-from . import hilbert
-from . import operator
 from . import driver
 from . import dynamics
-from . import sampler
-from . import models
-from . import vqs
+from . import hilbert
 from . import logging
-from . import qsr
+from . import models
 from . import observable
+from . import operator
+from . import qsr
+from . import sampler
+from . import vqs
 
 from .driver import TDVP
 from .qsr import QSR


### PR DESCRIPTION
## Summary
- re-add `hilbert` import next to the other module imports
- run `black` on `netket/experimental/__init__.py`

## Testing
- `black netket/experimental/__init__.py`
- `pre-commit run --files netket/experimental/__init__.py` *(fails: unable to access 'https://github.com/astral-sh/ruff-pre-commit/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_683f60c51990832281a821edf5016d7b